### PR TITLE
Fix dependency problems reported on the Package Index

### DIFF
--- a/detect/backdoor.rkt
+++ b/detect/backdoor.rkt
@@ -1,4 +1,4 @@
-#lang errortrace racket/base
+#lang racket/base
 
 (require racket/list
         racket/sequence

--- a/ground/load.rkt
+++ b/ground/load.rkt
@@ -6,7 +6,6 @@
     racket/vector
 	db
     graph
-    datalog
 	carl-lib/lang)
 
 (define (ground rules dbc)

--- a/test/embed.rkt
+++ b/test/embed.rkt
@@ -1,4 +1,4 @@
-#lang errortrace racket/base
+#lang racket/base
 
 (require rackunit
     carl-lib/ground

--- a/test/ground.rkt
+++ b/test/ground.rkt
@@ -1,4 +1,4 @@
-#lang errortrace racket/base
+#lang racket/base
 
 (require rackunit
     db

--- a/test/integration.rkt
+++ b/test/integration.rkt
@@ -1,4 +1,4 @@
-#lang errortrace racket/base
+#lang racket/base
 
 (require rackunit
 	       racket/lazy-require


### PR DESCRIPTION
Remove unused dependencies on `datalog` and `errortrace-lib`.